### PR TITLE
🐛 Fix lint command is not work

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,12 @@
   "parserOptions": {
     "ecmaVersion": 2020
   },
-  "extends": ["next/core-web-vitals", "prettier"]
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:react/jsx-runtime",
+    "prettier"
+  ],
+  "rules": {
+    "react/jsx-indent": [2, 2, {"checkAttributes": true}]
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,17 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true,
+  "[typescript]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.prettier": false,
+      "source.fixAll.eslint": true
+    }
+  },
+  "[typescriptreact]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.prettier": false,
+      "source.fixAll.eslint": true
+    }
+  },
+  "eslint.validate": ["typescript"],
   "files.associations": {
     "*.css": "tailwindcss"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,14 +18,14 @@
         "autoprefixer": "10.4.14",
         "babel-loader": "^9.1.3",
         "eslint": "8.45.0",
-        "eslint-config-next": "13.4.12",
+        "eslint-config-next": "^13.4.12",
         "next": "^13.4.12",
         "postcss": "8.4.27",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-icons": "^4.10.1",
         "tailwindcss": "^3.3.3",
-        "typescript": "5.1.6"
+        "typescript": "^5.0.4"
       },
       "devDependencies": {
         "eslint-config-prettier": "^8.8.0",
@@ -7123,15 +7123,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=12.20"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     "autoprefixer": "10.4.14",
     "babel-loader": "^9.1.3",
     "eslint": "8.45.0",
-    "eslint-config-next": "13.4.12",
+    "eslint-config-next": "^13.4.12",
     "next": "^13.4.12",
     "postcss": "8.4.27",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.10.1",
     "tailwindcss": "^3.3.3",
-    "typescript": "5.1.6"
+    "typescript": "^5.0.4"
   },
   "devDependencies": {
     "eslint-config-prettier": "^8.8.0",


### PR DESCRIPTION
## Summary
- FIx to work complete `next lint`
    - Next.js 13.4 is not supported typescript@5.1
- few tuning

## Tests
- `npm run lint` is working